### PR TITLE
set +x to assure creds won't be dumped to logs

### DIFF
--- a/assume_role.sh
+++ b/assume_role.sh
@@ -1,4 +1,5 @@
 function assume {
+  set +x
   region=us-east-1
   profile=$1
   role=$2

--- a/assume_role_nomfa.sh
+++ b/assume_role_nomfa.sh
@@ -4,6 +4,7 @@
 ## This function takes only one argument, the role name.  
 
 assume() {
+  set +x
   role="$1"
   duration=1800
   result="$(aws sts assume-role --role-arn "$role" \


### PR DESCRIPTION
I've noticed lots of jenkins jobs that have copy/pasted this script and
are running with 'set -x', which results in AWS creds ending up in log
files.
